### PR TITLE
Remote url support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 tmp
+**/*.js
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 Node implementation of [MediaArea's MediaInfo](https://mediaarea.net/en/MediaInfo) WebAssembly binary.
 
 ## Install
-
 ```sh
 $ npm install --save node-mediainfo
 ```
 
 ## Usage
-
 ```ts
 // Using ES6 imports
 import mediainfo from 'node-mediainfo';
@@ -20,7 +18,7 @@ import mediainfo from 'node-mediainfo';
 const mediainfo = require('node-mediainfo');
 
 async function main() {
-  const result = await mediainfo('path to media file');
+  const result = await mediainfo('<File or URL>');
   console.log(result);
 }
 
@@ -32,6 +30,4 @@ main();
 - Package: [npmjs.com/package/node-mediainfo](https://www.npmjs.com/package/node-mediainfo)
 
 ## License
-
-
 This package uses [MediaInfo](http://mediaarea.net/MediaInfo) library, Copyright (c) 2002-2019 [MediaArea.net SARL](mailto:Info@MediaArea.net)

--- a/examples/stream.ts
+++ b/examples/stream.ts
@@ -1,9 +1,11 @@
 import mediainfo from '../src';
 
-mediainfo('<full path to file>').then(
+mediainfo('<File or URL>').then(
   (response) => {
     console.log(JSON.stringify(
       response, null, 2,
     ));
   },
-);
+).catch((err) => {
+  console.error(err);
+});

--- a/examples/stream.ts
+++ b/examples/stream.ts
@@ -1,6 +1,6 @@
 import mediainfo from '../src';
 
-mediainfo('<File or URL>').then(
+mediainfo('http://dl5.webmfiles.org/big-buck-bunny_trailer.webm').then(
   (response) => {
     console.log(JSON.stringify(
       response, null, 2,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "types": "tsc --outDir tmp src/build.ts --lib es2017 && node tmp/build"
   },
   "dependencies": {
+    "@types/request": "^2.48.4",
     "request": "^2.88.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "build": "npm run types && tsc",
     "prepare": "npm run build",
     "types": "tsc --outDir tmp src/build.ts --lib es2017 && node tmp/build"
+  },
+  "dependencies": {
+    "request": "^2.88.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { PathLike, createReadStream, stat } from 'fs';
-import * as Request from 'request';
+import Request = require('request');
 import {
   Audio, General, Image, Menu, Other, Text, Video,
 } from './types';
@@ -32,11 +32,11 @@ async function GetSize(path: PathLike, headers = {}) {
     if (path.toString().indexOf('http') === 0) {
       return Request({
         method: 'HEAD',
-        url: path,
+        url: path.toString(),
         headers
-      }).on('response', (res) => {
+      }).on('response', (res: any) => {
         resolve(parseInt(res.headers['content-length'], 10) || 0);
-      }).on('error', (err) => {
+      }).on('error', (err: Error) => {
         reject(err);
       })
     }
@@ -49,10 +49,10 @@ async function GetSize(path: PathLike, headers = {}) {
   })
 }
 
-function GetStream(path: PathLike, start = 0, length = -1, headers = {}) {
+function GetStream(path: PathLike, start = 0, length = -1, headers = {}): any {
   if (path.toString().indexOf('http') === 0) {
     return Request({
-      url: path,
+      url: path.toString(),
       headers: {
         ...headers,
         Range: `bytes=${start}-${length}`
@@ -81,14 +81,14 @@ export default function MediaInfo(path: PathLike, headers = {}): Promise<MediaIn
     MI.Open_Buffer_Init(size, 0);
 
 
-    stream.on('data', (chunk) => {
+    stream.on('data', (chunk: any) => {
       MI.Open_Buffer_Continue(chunk);
       seekTo = MI.Open_Buffer_Continue_Goto_Get();
       // console.log('SeekTo', seekTo);
 
       if (seekTo !== -1) {
         MI.Open_Buffer_Init(size, seekTo);
-        if (stream.close) {
+        if (typeof (stream.close) !== 'undefined') {
           stream.close();
         }
       }
@@ -97,7 +97,7 @@ export default function MediaInfo(path: PathLike, headers = {}): Promise<MediaIn
     stream.on('close', () => {
       const newstream = GetStream(path, seekTo, 1024 * 1024, headers);
 
-      newstream.on('data', (chunk) => {
+      newstream.on('data', (chunk: any) => {
         MI.Open_Buffer_Continue(chunk);
         seekTo = MI.Open_Buffer_Continue_Goto_Get();
         // console.log('SeekTo', seekTo);


### PR DESCRIPTION
Hello,

Thanks for your project, it looks nice and works well 😉

This PR adds the URL support, now you can put any http(s) url to get information about any remote file 🥰

```
import mediainfo from '../src';

mediainfo('http://dl5.webmfiles.org/big-buck-bunny_trailer.webm').then(
  (response) => {
    console.log(JSON.stringify(
      response, null, 2,
    ));
  },
).catch((err) => {
  console.error(err);
});
```

The `mediainfo` function now takes an headers object as second paramters, in case of you need to send auth headers  😎

I made changes about the package export, can you check if I broke something?
I didn't updated the `yarn.lock` file, can you update it? 

Have a great day,
I hope you'll merge and release it asap 😏